### PR TITLE
Fix error when snapshot response is missing content-type header

### DIFF
--- a/octoprint_octolapse/camera.py
+++ b/octoprint_octolapse/camera.py
@@ -578,7 +578,7 @@ class CameraControl(object):
                     message = "The request contained no data for the '{0}' camera profile.".format(camera_profile.name)
                     logger.error(message)
                     raise CameraError('request-contained-no-data', message)
-                elif "image/jpeg" not in r.headers["content-type"].lower():
+                elif 'content-type' in r.headers and "image/jpeg" not in r.headers["content-type"].lower():
                     message = (
                         "The returned data was not an image for the '{0}' camera profile.".format(camera_profile.name)
                     )


### PR DESCRIPTION
Fixes internal server error when snapshot URL returns otherwise valid image without any content-type header after pressing “Test Webcam”
![IMG_7676](https://user-images.githubusercontent.com/1612377/149622300-c5926c18-260a-496b-abd5-1f06a772b52f.jpeg)

